### PR TITLE
Add  for, until, and while loops to defaults list

### DIFF
--- a/lib/sshkit/command_map.rb
+++ b/lib/sshkit/command_map.rb
@@ -62,7 +62,7 @@ module SSHKit
 
     def defaults
       Hash.new do |hash, command|
-        if %w{if test time exec}.include? command.to_s
+        if %w{exec for if test time until while}.include? command.to_s
           hash[command] = command.to_s
         else
           hash[command] = "/usr/bin/env #{command}"


### PR DESCRIPTION
Without these loop keywords, the `within` block was ignored.
Example:
```ruby
within "path" do
  execute('for i in {1..10}; do echo hi; done')
end
# Old
'cd "path" && /usr/bin/env for i in {1..10}; do echo hi; done'
# New
'cd "path" && for i in {1..10}; do echo hi; done'
```

To be honest, this patch still doesn't fix other issues. For example
```ruby
within "path" do
  execute('bin/command run')
end
'cd "path" && /usr/bin/env bin/command run'
```
..will not be able to find the command. A better method might be a regex.